### PR TITLE
force X11 and integrate wemeet-wayland-screenshare

### DIFF
--- a/com.tencent.wemeet.yml
+++ b/com.tencent.wemeet.yml
@@ -1,6 +1,6 @@
 app-id: com.tencent.wemeet
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 separate-locales: false
 rename-icon: wemeet
@@ -10,13 +10,18 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=x11
-  - --socket=wayland
   - --socket=pulseaudio
   - --device=all
   - --filesystem=xdg-run/pipewire-0
   - --talk-name=org.gnome.Shell.Screencast
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --env=XDG_SESSION_TYPE=x11
+  - --env=QT_QPA_PLATFORM=xcb
+  - --env=LD_PRELOAD=/app/lib/wemeet/libhook.so
+  - --unset-env=WAYLAND_DISPLAY
+  # Hidpi scale
+  - --env=QT_AUTO_SCREEN_SCALE_FACTOR=1
 cleanup:
   - /include
   - /lib/cmake
@@ -73,6 +78,18 @@ modules:
           project-id: 6615
           stable-only: true
           url-template: https://github.com/opencv/opencv_contrib/archive/$version.tar.gz
+
+  - name: wemeet-wayland-screenshare
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    post-install:
+      - ln -Tsv /usr/lib/$(gcc --print-multiarch)/libXext.so.? /app/lib/libXext.so
+      - ln -Tsv /usr/lib/$(gcc --print-multiarch)/libXdamage.so.? /app/lib/libXdamage.so
+    sources:
+      - type: git
+        url: https://github.com/xuwd1/wemeet-wayland-screenshare.git
+        commit: ab226c63380c4233e2f490ba17e6ea8f393999e2
 
   - name: wemeet
     buildsystem: simple


### PR DESCRIPTION
Switch WeMeet to run under XWayland by unsetting WAYLAND_DISPLAY and forcing QT_QPA_PLATFORM=xcb, and bundle xuwd1/wemeet-wayland-screenshare so screen sharing works on Wayland sessions.


wayland 环境没这个的话共享就坏了。不合并没关系，看能不能利用一下 flathub 的构建。